### PR TITLE
Make logger display method without enum name

### DIFF
--- a/lib/Middleware.rakumod
+++ b/lib/Middleware.rakumod
@@ -23,7 +23,7 @@ use v6;
 unit module Humming-Bird::Middleware;
 
 sub m_logger($request, $response, &next) is export {
-    say sprintf("%s %s | %s %s", $request.method.raku, $request.path, $request.version, $request.header('User-Agent') || 'Unknown Agent');
+    say sprintf("%s %s | %s %s", $request.method.Str, $request.path, $request.version, $request.header('User-Agent') || 'Unknown Agent');
     &next();
 }
 


### PR DESCRIPTION
`HTTPMethod::GET` -> `GET` when logging.