### PR TITLE
Fix crash on unsupported route

### DIFF
--- a/lib/Humming-Bird.rakumod
+++ b/lib/Humming-Bird.rakumod
@@ -262,6 +262,11 @@ sub dispatch_request(Request $request --> Response) {
         }
     }
 
+    # If we don't support the request method on this route.
+    if not %loc{$request.method}:exists {
+        return Response.new(status => HTTP::Status(405)).html('405 Method Not Allowed');
+    }
+
     %loc{$request.method}($request);
 }
 


### PR DESCRIPTION
Before, if the server had a route on a given path but had a different method, it could cause a crash. This guards against it.