### PR TITLE
Add "advice" and Error handlers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Install App::Prove6
         run: zef install --/test App::Prove6
       - name: Run Tests
-        run: prove6 -I. t
+        run: prove6 -I. t/ it/

--- a/META6.json
+++ b/META6.json
@@ -16,7 +16,8 @@
   "provides": {
     "Humming-Bird::Core": "lib/Humming-Bird/Core.rakumod",
     "Humming-Bird::HTTPServer": "lib/Humming-Bird/HTTPServer.rakumod",
-    "Humming-Bird::Middleware": "lib/Humming-Bird/Middleware.rakumod"
+    "Humming-Bird::Middleware": "lib/Humming-Bird/Middleware.rakumod",
+	"Humming-Bird::Advice": "lib/Humming-Bird/Advice.rakumod"
   },
   "resources": [
   ],
@@ -35,5 +36,5 @@
     "Test::When",
     "Test::Notice"
   ],
-  "version": "1.1.5"
+  "version": "1.1.6"
 }

--- a/META6.json
+++ b/META6.json
@@ -34,7 +34,9 @@
   "test-depends": [
     "Test",
     "Test::When",
-    "Test::Notice"
+    "Test::Notice",
+	"Test::Util::ServerPort",
+	"Cro::HTTP::Client"
   ],
   "version": "1.1.6"
 }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ use Humming-Bird::Middleware;
 
 get('/logged', -> $request, $response {
     $response.html('This request has been logged!');
-}, [ &m_logger ]); # &m_logger is provided by Humming-Bird::Middleware
+}, [ &middleware-logger ]); # &middleware-logger is provided by Humming-Bird::Middleware
 
 # Custom middleware
 sub block-firefox($request, $response, &next) {
@@ -69,7 +69,7 @@ sub block-firefox($request, $response, &next) {
 
 get('/no-firefox', -> $request, $response {
     $response.html('You are not using Firefox!');
-}, [ &m_logger, &block-firefox ]);
+}, [ &middleware-logger, &block-firefox ]);
 
 # Scoped middleware
 
@@ -82,7 +82,7 @@ group([
     &post.assuming('/users', -> $request, $response {
         $response.write($request.body).status(204);
     })
-], [ &m_logger, &block-firefox ]);
+], [ &middleware-logger, &block-firefox ]);
 ```
 
 More examples can be found in the [examples](https://github.com/rawleyfowler/Humming-Bird/tree/main/examples) directory.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Humming-Bird is not meant to face the internet directly. Please use a reverse pr
 
 #### Simple example:
 ```raku
-use v6;
+use v6.d;
 
 use Humming-Bird::Core;
 
@@ -52,7 +52,7 @@ listen(8080);
 
 #### Middleware
 ```raku
-use v6;
+use v6.d;
 
 use Humming-Bird::Core;
 use Humming-Bird::Middleware;

--- a/examples/README.pod
+++ b/examples/README.pod
@@ -67,7 +67,7 @@
 
   get('/logged', -> $request, $response {
       $response.html('This request has been logged!');
-  }, [ &m_logger ]); # &m_logger is provided by Humming-Bird::Middleware
+  }, [ &middleware-logger ]); # &m_logger is provided by Humming-Bird::Middleware
 
   # Custom middleware
   sub block-firefox($request, $response, &next) {
@@ -77,7 +77,7 @@
 
   get('/no-firefox', -> $request, $response {
       $response.html('You are not using Firefox!');
-  }, [ &m_logger, &block-firefox ]);
+  }, [ &middleware-logger, &block-firefox ]);
 
   # Scoped middleware
 
@@ -90,7 +90,7 @@
       &post.assuming('/users', -> $request, $response {
           $response.write($request.body).status(204);
       })
-  ], [ &m_logger, &block-firefox ]);
+  ], [ &middleware-logger, &block-firefox ]);
 
 =head4 Cookies:
 
@@ -146,7 +146,7 @@
 
   get('/users', -> $request, $response {
       $response.json(marshal(@user-database));
-  }, [ &m_logger ]);
+  }, [ &middleware-logger ]);
 
   post('/users', -> $request, $response {
       my $user := unmarshal($request.body, User);

--- a/examples/README.pod6
+++ b/examples/README.pod6
@@ -185,5 +185,5 @@
   # This will catch any X::AdHoc exceptions and use this as the handler
   error(X::AdHoc, -> $exception {
     my $status = HTTP::Status(500);
-    Response.new(:$status).write($status.payload || 'Internal server error.');
+    Response.new(:$status).write($exception.payload || 'Internal server error.'); # In this case, when we hit an X::AdHoc lets return a 500 with the payload of the exception
   });

--- a/examples/README.pod6
+++ b/examples/README.pod6
@@ -155,3 +155,35 @@
   });
 
   listen(8080);
+
+=head4 After middleware aka advice
+
+=for code
+  use v6.d;
+  
+  use Humming-Bird::Core;
+  use Humming-Bird::Advice;
+  
+  advice(&advice-logger); # advice-logger is provided by Humming-Bird::Advice.
+  
+  # Custom advice
+  our clicks-today = 0;
+  sub update-clicks-today(Response:D $response --> Response:D) {
+	clicks-today++;
+	$response;
+  }
+  
+  advice(&update-clicks-today); # This will fire after every response is handled.
+
+=head4 Exception/Error handlers
+
+=for code
+  use v6.d;
+
+  use Humming-Bird::Core;
+
+  # This will catch any X::AdHoc exceptions and use this as the handler
+  error(X::AdHoc, -> $exception {
+    my $status = HTTP::Status(500);
+    Response.new(:$status).write($status.payload || 'Internal server error.');
+  });

--- a/examples/basic/basic.raku
+++ b/examples/basic/basic.raku
@@ -3,6 +3,7 @@ use strict;
 
 use Humming-Bird::Core;
 use Humming-Bird::Middleware;
+use Humming-Bird::Advice;
 
 # Simple static routes
 get('/', -> $request, $response {
@@ -38,7 +39,7 @@ get('/help.txt', -> $request, $response {
 # Simple Middleware example
 get('/logged', -> $request, $response {
     $response.html('<h1>Your request has been logged. Check the console.</h1>');
-}, [ &m_logger ]); # m_logger is provided by Humming-Bird::Middleware
+}, [ &middleware-logger ]); # m_logger is provided by Humming-Bird::Middleware
 
 
 # Custom Middleware example
@@ -52,7 +53,7 @@ sub block_firefox($request, $response, &next) {
 
 get('/firefox-not-allowed', -> $request, $response {
     $response.html('<h1>Hello Non-firefox user!</h1>');
-}, [ &m_logger, &block_firefox ]); # Many middlewares can be combined.
+}, [ &middleware-logger, &block_firefox ]); # Many middlewares can be combined.
 
 # Grouping routes
 # group: @route_callbacks, @middleware
@@ -64,7 +65,7 @@ group([
     &get.assuming('/hello/world', -> $request, $response {
         $response.html('<h1>Hello World!</h1>');
     })
-], [ &m_logger, &block_firefox ]);
+], [ &middleware-logger, &block_firefox ]);
 
 
 # Simple cookie
@@ -96,6 +97,9 @@ post('/auth/login', -> $request, $response {
 get('/take/me/home', -> $request, $response {
     $response.redirect('/', :permanent); # Do not provide permanent for a status of 307.
 });
+
+# After middleware, Response --> Response
+advice(&advice-logger);
 
 # Run the application
 listen(9000);

--- a/examples/basic/basic.raku
+++ b/examples/basic/basic.raku
@@ -93,10 +93,18 @@ post('/auth/login', -> $request, $response {
 
 
 # Redirects
-
 get('/take/me/home', -> $request, $response {
     $response.redirect('/', :permanent); # Do not provide permanent for a status of 307.
 });
+
+
+# Error throwing exception
+get('/throws-error', -> $request, $response {
+    $response.html('abc.html'.IO.slurp);
+});
+
+# Error handler
+error(X::AdHoc, -> $exn { Response.new(status => HTTP::Status(500)).write("Encountered an error.") });
 
 # After middleware, Response --> Response
 advice(&advice-logger);

--- a/it/01-basic.rakutest
+++ b/it/01-basic.rakutest
@@ -1,0 +1,32 @@
+use v6;
+
+use Test;
+
+use Humming-Bird::Core;
+use Test::Util::ServerPort;
+use Cro::HTTP::Client;
+
+plan 3;
+
+my $body = 'abc';
+
+get('/', -> $request, $response {
+	$response.write($body);
+});
+
+my $port = get-unused-port;
+
+listen($port, :no-block);
+
+sleep 1; # Yes, yes, I know
+
+my $base-uri = "http://0.0.0.0:$port";
+
+my $client = Cro::HTTP::Client.new: :$base-uri;
+my $response;
+lives-ok({ $response = await $client.get('/') });
+
+ok $response, 'Was response a success?';
+is (await $response.body-text), 'abc', 'Is response body OK?';
+
+done-testing;

--- a/it/02-error-handlers.rakutest
+++ b/it/02-error-handlers.rakutest
@@ -1,0 +1,36 @@
+use v6;
+
+use Test;
+
+use Humming-Bird::Core;
+use Test::Util::ServerPort;
+use Cro::HTTP::Client;
+use HTTP::Status;
+
+plan 4;
+
+get('/', -> $request, $response {
+	die 'adhoc';
+	$response.write('body');
+});
+
+error(X::AdHoc, sub ($exception) {
+	return Response.new(status => HTTP::Status(204)).write($exception.Str);
+});
+
+my $port = get-unused-port;
+
+listen($port, :no-block);
+
+sleep 1; # Yes, yes, I know
+
+my $base-uri = "http://0.0.0.0:$port";
+
+my $client = Cro::HTTP::Client.new: :$base-uri;
+my $response;
+lives-ok({ $response = await $client.get('/') });
+ok $response, 'Was response a success?';
+is $response.status, 204, 'Is response status OK?';
+is (await $response.body-text), 'adhoc', 'Is error body OK?';
+
+done-testing;

--- a/it/03-middlewares.rakutest
+++ b/it/03-middlewares.rakutest
@@ -1,0 +1,45 @@
+use v6;
+
+use Test;
+
+use Humming-Bird::Core;
+use Test::Util::ServerPort;
+use Cro::HTTP::Client;
+use HTTP::Status;
+
+plan 5;
+
+sub test-middleware($request, $response, &next) {
+	$response.status(204).write('abc');
+}
+
+my $i = 0;
+sub my-incr-middleware($request, $response, &next) {
+	$i++;
+	&next();
+}
+
+get('/', -> $request, $response {
+	$response.status(200).write('body'); # This shouldn't be hit.
+}, [ &my-incr-middleware, &test-middleware ]);
+
+my $port = get-unused-port;
+
+listen($port, :no-block);
+
+sleep 1; # Yes, yes, I know
+
+my $base-uri = "http://0.0.0.0:$port";
+
+my $client = Cro::HTTP::Client.new: :$base-uri;
+
+my $response;
+
+lives-ok({ $response = await $client.get('/') });
+
+ok $response, 'Was response a success?';
+is $response.status, 204, 'Is response status 204?';
+is (await $response.body-text), 'abc', 'Is response body OK?';
+is $i, 1, 'Is increment middleware working?';
+
+done-testing;

--- a/lib/Humming-Bird/Advice.rakumod
+++ b/lib/Humming-Bird/Advice.rakumod
@@ -1,0 +1,28 @@
+=begin pod
+=head1 Humming-Bird::Middleware
+
+Simple middleware for the Humming-Bird web-framework.
+
+=head2 Exported middlewares
+
+=head3 middleware-logger
+
+=for code
+    use Humming-Bird::Core;
+    use Humming-Bird::Advice;
+	advice(&advice-logger);
+
+This advice will concisely log all traffic leaving this route.
+
+=end pod
+
+use v6;
+
+use Humming-Bird::Core;
+
+unit module Humming-Bird::Advice;
+
+sub advice-logger(Response $response --> Response) is export {
+	say "{ $response.status } | { $response.header('Content-Type') }";
+	$response;
+}

--- a/lib/Humming-Bird/Advice.rakumod
+++ b/lib/Humming-Bird/Advice.rakumod
@@ -23,6 +23,6 @@ use Humming-Bird::Core;
 unit module Humming-Bird::Advice;
 
 sub advice-logger(Response $response --> Response) is export {
-	say "{ $response.status } | { $response.header('Content-Type') }";
+	say "{ $response.status.Int } { $response.status } | { $response.header('Content-Type') }";
 	$response;
 }

--- a/lib/Humming-Bird/Advice.rakumod
+++ b/lib/Humming-Bird/Advice.rakumod
@@ -1,18 +1,19 @@
 =begin pod
-=head1 Humming-Bird::Middleware
+=head1 Humming-Bird::Advice
 
-Simple middleware for the Humming-Bird web-framework.
+Simple advice for the Humming-Bird web-framework. Advice are end-of-cycle
+middlewares. They take a Response and return a Response.
 
-=head2 Exported middlewares
+=head2 Exported advice
 
-=head3 middleware-logger
+=head3 advice-logger
 
 =for code
     use Humming-Bird::Core;
     use Humming-Bird::Advice;
 	advice(&advice-logger);
 
-This advice will concisely log all traffic leaving this route.
+This advice will concisely log all traffic leaving the application.
 
 =end pod
 

--- a/lib/Humming-Bird/Core.rakumod
+++ b/lib/Humming-Bird/Core.rakumod
@@ -444,8 +444,9 @@ sub handle($raw-request) {
     my Request $request = Request.encode($raw-request);
     my Bool $keep-alive = False;
     my &advice = [o] @ADVICE; # Advice are Response --> Response
+
     with $request.headers<Connection> {
-        $keep-alive = $request.headers<Connection>.lc eq 'keep-alive';
+        $keep-alive = $_.lc eq 'keep-alive';
     }
 
     # If the request is HEAD, we shouldn't return the body

--- a/lib/Humming-Bird/Core.rakumod
+++ b/lib/Humming-Bird/Core.rakumod
@@ -425,7 +425,7 @@ multi sub advice(--> List:D) is export {
 }
 
 multi sub advice(@advice) is export {
-    @ADVICE.push: |@advice;
+    @ADVICE.append: @advice;
 }
 
 multi sub advice(&advice) is export {

--- a/lib/Humming-Bird/Core.rakumod
+++ b/lib/Humming-Bird/Core.rakumod
@@ -359,7 +359,7 @@ sub dispatch-request(Request $request --> Response) {
     for @uri_parts -> $uri {
         my $possible_param = %loc.keys.first: *.starts-with($PARAM_IDX);
 
-        if (not %loc{$uri}:exists) && !$possible_param {
+        if  %loc{$uri}:!exists && !$possible_param {
             return $NOT-FOUND;
         } elsif $possible_param && !%loc{$uri} {
             $request.params{$possible_param.match(/<[A..Z a..z 0..9 \- \_]>+/).Str} = $uri;

--- a/lib/Humming-Bird/Core.rakumod
+++ b/lib/Humming-Bird/Core.rakumod
@@ -410,6 +410,10 @@ sub group(@routes, @middlewares) is export {
     .(@middlewares) for @routes;
 }
 
+multi sub advice(--> List:D) is export {
+    @ADVICE.clone;
+}
+
 multi sub advice(@advice) is export {
     @ADVICE.push: |@advice;
 }

--- a/lib/Humming-Bird/Middleware.rakumod
+++ b/lib/Humming-Bird/Middleware.rakumod
@@ -5,16 +5,16 @@ Simple middleware for the Humming-Bird web-framework.
 
 =head2 Exported middlewares
 
-=head3 m_logger
+=head3 middleware-logger
 
 =for code
     use Humming-Bird::Core;
     use Humming-Bird::Middleware;
     get('/', -> $request, $response {
         $response.html('<h1>Hello World!</h1>');
-    }, [ &m_logger ]);
+    }, [ &middleware-logger ]);
 
-This middleware will concisely log all traffic traffic heading for this route.
+This middleware will concisely log all traffic heading for this route.
 
 =end pod
 
@@ -22,7 +22,7 @@ use v6;
 
 unit module Humming-Bird::Middleware;
 
-sub m_logger($request, $response, &next) is export {
+sub middleware-logger($request, $response, &next) is export {
     say sprintf("%s %s | %s %s", $request.method.Str, $request.path, $request.version, $request.header('User-Agent') || 'Unknown Agent');
     &next();
 }

--- a/sparrow.yaml
+++ b/sparrow.yaml
@@ -8,5 +8,4 @@ tasks:
       cd source/
       zef install App::Prove6 --force-install
       prove6 -I. it/
-      zef install --deps-only --/test .
-      zef test . -v
+      prove6 -I. t/

--- a/sparrow.yaml
+++ b/sparrow.yaml
@@ -6,5 +6,7 @@ tasks:
     code: |
       set -e
       cd source/
+      zef install App::Prove6 --force-install
+      prove6 -I. it/
       zef install --deps-only --/test .
       zef test . -v

--- a/sparrow.yaml
+++ b/sparrow.yaml
@@ -7,5 +7,4 @@ tasks:
       set -e
       cd source/
       zef install App::Prove6 --force-install
-      prove6 -I. it/
-      prove6 -I. t/
+      prove6 -I. t/ it/

--- a/t/04-middleware.rakutest
+++ b/t/04-middleware.rakutest
@@ -10,9 +10,9 @@ plan 4;
 
 get('/', -> $request, $response {
   $response.html('Hello World!');
-}, [ &m_logger ]);
+}, [ &middleware-logger ]);
 
-is routes{'/'}{GET}.middlewares[0].raku, &m_logger.raku, 'Is middleware properly assigned?';
+is routes{'/'}{GET}.middlewares[0].raku, &middleware-logger.raku, 'Is middleware properly assigned?';
 is routes{'/'}{GET}.middlewares[0].elems, 1, 'Is proper number of middleware inside of route?';
 
 group((
@@ -22,7 +22,7 @@ group((
   &get.assuming('/hello/world', -> $request, $response {
     $response.html('Hello World!');
   })
-), [ &m_logger ]);
+), [ &middleware-logger ]);
 
-is routes{'/'}{'hello'}{GET}.middlewares[0].raku, &m_logger.raku, 'Is middleware of group properly assigned?';
-is routes{'/'}{'hello'}{'world'}{GET}.middlewares[0].raku, &m_logger.raku, 'Is middleware of group properly assigned?';
+is routes{'/'}{'hello'}{GET}.middlewares[0].raku, &middleware-logger.raku, 'Is middleware of group properly assigned?';
+is routes{'/'}{'hello'}{'world'}{GET}.middlewares[0].raku, &middleware-logger.raku, 'Is middleware of group properly assigned?';

--- a/t/07-advice.rakutest
+++ b/t/07-advice.rakutest
@@ -1,0 +1,27 @@
+use v6.d;
+
+use Test;
+
+use Humming-Bird::Core;
+
+plan 3;
+
+sub custom-advice(Response $response --> Response) {
+	return $response.write('abc');
+}
+
+get('/abc', -> $request, $response {
+	$response.status(204);
+});
+
+advice(&custom-advice);
+
+# [1] because the identity function is the root advice.
+is advice()[1].raku, &custom-advice.raku, 'Is advice set properly?';
+
+my $dumby-request = Request.new(path => '/abc', method => GET, version => 'HTTP/1.1');
+my &cb = [o] advice();
+is &cb(routes{'/'}{'abc'}{GET}($dumby-request)).body, 'abc', 'Is body set correctly by Advice?';
+is &cb(routes{'/'}{'abc'}{GET}($dumby-request)).status.Int, 204, 'Does response still have old values after advice?';
+
+done-testing;


### PR DESCRIPTION
### Advice

Advice function as end of stack middleware, they take Responses and return Responses.

middleware -> actual handler -> advice

Declare them like:
```raku
advice(-> $response { say $response; $response });
```

### Error Handlers

Error handlers can be added by specific type of error, they will catch any exception thrown of type error provided and pass the error as a parameter to the handler.

Too catch all `X::AdHoc` you would do:
```raku
error(X::AdHoc, -> $exn { Response.new(status => Http::Status(500) });
```