### PR TITLE
Add catch-all routes

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -38,5 +38,5 @@
 		"Test::Util::ServerPort",
 		"Cro::HTTP::Client"
 	],
-	"version": "2.0.1"
+	"version": "2.0.2"
 }

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ some people get involved :D
 
 Please make sure you squash your branch, and name it accordingly before it gets merged!
 
+Before submitting any feature/code pull requests, ensure that the following passes:
+```bash
+cd Humming-Bird
+prove6 -I. t/ it/
+```
+
 ## License
 Humming-Bird is available under the MIT, you can view the license in the `LICENSE` file
 at the root of the project. For more information about the MIT, please click

--- a/it/04-catch-all-routes.rakutest
+++ b/it/04-catch-all-routes.rakutest
@@ -6,7 +6,7 @@ use Humming-Bird::Core;
 use Test::Util::ServerPort;
 use Cro::HTTP::Client;
 
-plan 9;
+plan 12;
 
 my $body = 'abc';
 
@@ -14,8 +14,8 @@ get('/abc/**', -> $request, $response {
 	$response.write($body);
 });
 
-get('/abc/john', -> $request, $response { $response.write('JOHN'); });
-
+get('/**', -> $request, $response { $response.write('EFG') });
+get('/abc/john', -> $request, $response { $response.write('JOHN') });
 get('/lol/bob/**', -> $request, $response { $response.write('LOL!') });
 
 my $port = get-unused-port;
@@ -40,5 +40,9 @@ is (await $response.body-text), 'JOHN', 'Is nested response body OK?';
 lives-ok({ $response = await $client.get('/lol/bob/bobby/dude/abc') }, 'Does long request live OK?');
 ok $response, 'Was long response a success?';
 is (await $response.body-text), 'LOL!', 'Is long response body OK?';
+
+lives-ok({ $response = await $client.get('/k/efg/kadljaslkdaldjas') }, 'Does deep catch-all live OK?');
+ok $response, 'Was deep response a success?';
+is (await $response.body-text), 'EFG', 'Is deep response body OK?';
 
 done-testing;

--- a/it/04-catch-all-routes.rakutest
+++ b/it/04-catch-all-routes.rakutest
@@ -1,0 +1,44 @@
+use v6;
+
+use Test;
+
+use Humming-Bird::Core;
+use Test::Util::ServerPort;
+use Cro::HTTP::Client;
+
+plan 9;
+
+my $body = 'abc';
+
+get('/abc/**', -> $request, $response {
+	$response.write($body);
+});
+
+get('/abc/john', -> $request, $response { $response.write('JOHN'); });
+
+get('/lol/bob/**', -> $request, $response { $response.write('LOL!') });
+
+my $port = get-unused-port;
+
+listen($port, :no-block);
+
+sleep 1; # Yes, yes, I know
+
+my $base-uri = "http://0.0.0.0:$port";
+
+my $client = Cro::HTTP::Client.new: :$base-uri;
+my $response;
+
+lives-ok({ $response = await $client.get('/abc/haha') }, 'Does request live OK?');
+ok $response, 'Was response a success?';
+is (await $response.body-text), 'abc', 'Is response body OK?';
+
+lives-ok({ $response = await $client.get('/abc/john') }, 'Does nested request live OK?');
+ok $response, 'Was nested request a success?';
+is (await $response.body-text), 'JOHN', 'Is nested response body OK?';
+
+lives-ok({ $response = await $client.get('/lol/bob/bobby/dude/abc') }, 'Does long request live OK?');
+ok $response, 'Was long response a success?';
+is (await $response.body-text), 'LOL!', 'Is long response body OK?';
+
+done-testing;

--- a/lib/Humming-Bird/Core.rakumod
+++ b/lib/Humming-Bird/Core.rakumod
@@ -299,12 +299,14 @@ sub dispatch-request(Request:D $request --> Response:D) {
     }
 
     my %loc := %ROUTES;
-    for @uri_parts -> $uri {        
+    my %catch-all;
+    for @uri_parts -> $uri {
         my $possible-param = %loc.keys.first: *.starts-with($PARAM_IDX);
+        %catch-all = %loc{$CATCH_ALL_IDX} if %loc.keys.first: * eq $CATCH_ALL_IDX;
 
         if %loc{$uri}:!exists && !$possible-param {
-            if %loc{$CATCH_ALL_IDX}:exists {
-                %loc := %loc{$CATCH_ALL_IDX};
+            if %catch-all {
+                %loc := %catch-all;
                 last;
             }
             


### PR DESCRIPTION
Fixes #30 

This allows the user to:

```raku
use v6.d;

use Humming-Bird;

get('/foo/**', -> $request, $response { $request.write('Foo **!') });

# Now all requests to /foo/** will hit that end point

# However, you can still define
get('/foo/bar', -> $request, $response { $request.write('Foo Bar!') });

# /foo/bar --> Foo Bar!
# /foo/baz --> Foo **!
```