### PR TITLE
Rework redirects to be more in line with other frameworks

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -39,5 +39,5 @@
 		"Test::Util::ServerPort",
 		"Cro::HTTP::Client"
 	],
-	"version": "2.0.6"
+	"version": "2.0.7"
 }

--- a/lib/Humming-Bird/Core.rakumod
+++ b/lib/Humming-Bird/Core.rakumod
@@ -9,7 +9,7 @@ use Humming-Bird::HTTPServer;
 
 unit module Humming-Bird::Core;
 
-our constant $VERSION = '2.0.6';
+our constant $VERSION = '2.0.7';
 
 # Mime type parser from MIME::Types
 my constant $mime = MIME::Types.new;
@@ -179,10 +179,13 @@ class Response is HTTPAction is export {
     }
 
     # Redirect to a given URI, :$permanent allows for a 308 status code vs a 307
-    method redirect(Str:D $to, :$permanent) {
+    method redirect(Str:D $to, :$permanent, :$temporary) {
         %.headers<Location> = $to;
-        self.status(307) without $permanent;
-        self.status(308) with $permanent;
+        self.status(303);
+
+        self.status(307) if $temporary;
+        self.status(308) if $permanent;
+        
         self;
     }
 

--- a/t/06-redirect.rakutest
+++ b/t/06-redirect.rakutest
@@ -4,15 +4,21 @@ use Test;
 use Humming-Bird::Core;
 use HTTP::Status;
 
-plan 4;
-
-get('/bob', -> $request, $response {
-  $response.redirect('/home');
-});
+plan 6;
 
 my $req = Request.new(path => '/', method => GET, version => 'HTTP/1.1');
-is routes{'/'}{'bob'}{GET}($req).header('Location'), '/home', 'Is redirect location OK?';
-is routes{'/'}{'bob'}{GET}($req).status, HTTP::Status(307), 'Is redirect status OK?';
+
+get('/john', sub ($request, $response) { $response.redirect('/home') });
+
+is routes{'/'}{'john'}{GET}($req).header('Location'), '/home', 'Is redirect location OK?';
+is routes{'/'}{'john'}{GET}($req).status, HTTP::Status(303), 'Is redirect status OK?';
+
+get('/bob', -> $request, $response {
+  $response.redirect('/home', :temporary);
+});
+
+is routes{'/'}{'bob'}{GET}($req).header('Location'), '/home', 'Is temporary redirect location OK?';
+is routes{'/'}{'bob'}{GET}($req).status, HTTP::Status(307), 'Is temporary redirect status OK?';
 
 get('/toby', -> $request, $response {
   $response.redirect('/home', :permanent);


### PR DESCRIPTION
This makes it so redirects rewrite requests to `GET` by default, typically used when moving between forms and their success states.