### PR TITLE
Add infered content

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,8 @@
 	"depends": [
 		"HTTP::Status",
 		"DateTime::Format",
-		"MIME::Types"
+		"MIME::Types",
+        "JSON::Fast"
 	],
 	"description": "A simple and composable web applications framework.",
 	"license": "MIT",

--- a/lib/Humming-Bird/Advice.rakumod
+++ b/lib/Humming-Bird/Advice.rakumod
@@ -24,6 +24,10 @@ use Humming-Bird::Core;
 unit module Humming-Bird::Advice;
 
 sub advice-logger(Response:D $response --> Response) is export {
-	say "{ $response.status.Int } { $response.status } | { $response.initiator.path } | { $response.header('Content-Type') }";
+    if $response.header('Content-Type') {
+	    say "{ $response.status.Int } { $response.status } | { $response.initiator.path } | { $response.header('Content-Type') }";
+    } else {
+	    say "{ $response.status.Int } { $response.status } | { $response.initiator.path } | no-content";
+    }
 	$response;
 }

--- a/lib/Humming-Bird/HTTPServer.rakumod
+++ b/lib/Humming-Bird/HTTPServer.rakumod
@@ -10,7 +10,7 @@ class Humming-Bird::HTTPServer is export {
     has Int:D $.port = 8080;
     has Int:D $.timeout is required;
     has Channel:D $.requests .= new;
-    has Lock $.lock .= new;
+    has Lock $!lock .= new;
     has @!connections;
 
     method !timeout {

--- a/t/10-content-guessing.rakutest
+++ b/t/10-content-guessing.rakutest
@@ -1,0 +1,21 @@
+use v6.d;
+use Humming-Bird::Core;
+use Test;
+
+plan 3;
+
+my $request = Request.new(body => '{ "foo": "bar" }', path => '/home', method => GET, version => 'HTTP/1.1');
+$request.header('Content-Type', 'application/json');
+
+is $request.content, { foo => 'bar' }, 'Is JSON content decoding OK?';
+
+$request = Request.new(body => 'bob=123&john=abc', path => '/home', method => GET, version => 'HTTP/1.1');
+$request.header('Content-Type', 'application/urlencoded');
+
+is $request.content, Map.new('bob', '123', 'john', 'abc'), 'Is urlencoded content decoding OK?';
+
+$request.body = 'tom=abc&bob=123,456,789&john=abc';
+
+is $request.content, Map.new('tom', 'abc', 'bob' => (123,456,789), 'john', 'abc'), 'Is complex urlencoded content decoding OK?';
+
+done-testing;


### PR DESCRIPTION
Fixes #46

This allows the user to instantly convert JSON and urlencoded bodies to Raku Maps:
```raku
use Humming-Bird::Core;

post('/', -> $request, $response {
    my %body = $request.content; # This will be an empty map if the body is not able to be parsed.
    $response.write(%body.Str);
});
```