### PR TITLE
Update README.md Simple JSON CRUD example

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ get('/users/:user', -> $request, $response {
     my $user = $request.param('user');
 
     if %users{$user}:exists {
-        $response.json(to-json: %users{$user});
+        $response.json(to-json %users{$user});
     } else {
         $response.status(404).html("Sorry, $user does not exist.");
     }


### PR DESCRIPTION
When using the Simple JSON CRUD example from the README as-is, I was hit with a trace that was resolved by removing the colon after the `to-json` call:

```
===SORRY!=== Error while compiling /home/sean/raku/Humming-Bird/main.raku
Unable to parse expression in argument list; couldn't find final ')' (corresponding starter was at line 12)
at /home/sean/raku/Humming-Bird/main.raku:12
------>         $response.json(to-json:⏏ %users{$user});
    expecting any of:
        colon pair
```

Without that line (and providing placeholder verification) it appears to behave as expected:

```
sean:Humming-Bird$ curl localhost:8080/users/bob
{
  "name": "bob"
}[ble: EOF]               
 sean:Humming-Bird$ curl -X POST localhost:8080/users/ -d "name=Bjorn"
sean:Humming-Bird$ curl localhost:8080/users/Bjorn
{
  "name": "Bjorn"
}
```