### PR TITLE
Fix HTML validator error

### DIFF
--- a/lib/Humming-Bird/Glue.rakumod
+++ b/lib/Humming-Bird/Glue.rakumod
@@ -399,7 +399,7 @@ class Response is HTTPAction is export {
         my $body-size = $.body.bytes;
 
         if $body-size > 0 && self.header('Content-Type') && self.header('Content-Type') !~~ /.*'octet-stream'.*/ {
-            %.headers<content-type> ~= '; charset=utf8';
+            %.headers<content-type> ~= '; charset=utf-8';
         }
 
         $out ~= sprintf("Content-Length: %d\r\n", $body-size);


### PR DESCRIPTION
Hello, microscopic change to quell this validator error:

https://validator.w3.org/nu/?doc=https%3A%2F%2Fhyperlink-redirect.seriousbusiness.international%2F

>Error: The encoding utf8 is not the preferred name of the character encoding in use. The preferred name is utf-8. (Charmod C024)