### PR TITLE
HotReload updates

### DIFF
--- a/it/06-hotreload.rakutest
+++ b/it/06-hotreload.rakutest
@@ -1,0 +1,16 @@
+use v6;
+
+use Test;
+use Humming-Bird::Core;
+plugin 'HotReload';
+
+plan 1;
+spurt "test-changes-06-hotreload", "Hamadryas";
+
+sub hotreload-pid-exists {
+	return True if $*CWD ~ '/.humming-bird.hotreload'.IO.e || '/tmp/.humming-bird.hotreload';
+	return False;
+}
+
+ok hotreload-pid-exists, 'PIDfile exists for HotReload Plugin';
+unlink "test-changes-06-hotreload";

--- a/lib/Humming-Bird/Plugin/HotReload.rakumod
+++ b/lib/Humming-Bird/Plugin/HotReload.rakumod
@@ -45,7 +45,7 @@ class Humming-Bird::Backend::HotReload does Humming-Bird::Backend {
                 if ($!should-refresh) {
                     self!kill-server();
                     self!start-server();
-		            say $reload-message;
+                    say $reload-message;
                     say 'File change detected, refreshing Humming-Bird...';
                     $!should-refresh = False;
                 }

--- a/lib/Humming-Bird/Plugin/HotReload.rakumod
+++ b/lib/Humming-Bird/Plugin/HotReload.rakumod
@@ -6,7 +6,7 @@ use File::Find;
 
 unit class Humming-Bird::Plugin::HotReload does Humming-Bird::Plugin;
 
-my $temp-file = $*CWD ~ '/.humming-bird.hotreload';
+my $temp-file = '/tmp/.humming-bird.hotreload' || $*CWD ~ '/.humming-bird.hotreload';
 
 my sub find-dirs(IO::Path:D $dir) {
     slip $dir.IO, slip find :$dir, :type<dir>

--- a/lib/Humming-Bird/Plugin/HotReload.rakumod
+++ b/lib/Humming-Bird/Plugin/HotReload.rakumod
@@ -37,15 +37,16 @@ class Humming-Bird::Backend::HotReload does Humming-Bird::Backend {
         self!observe();
         self!start-server();
 
-        say "\n" ~ 'Humming-Bird HotReload PID: ' ~ (await $!proc.pid) ~ "\n";
+        my $reload-message = "\n" ~ 'Humming-Bird HotReload PID: ' ~ (await $!proc.pid) ~ "\n";
 
         react {
             whenever signal(SIGINT) { $temp-file.IO.unlink; exit; }
             whenever Supply.interval(1, 2) {
                 if ($!should-refresh) {
-                    say 'File change detected, refreshing Humming-Bird...';
                     self!kill-server();
                     self!start-server();
+		    say $reload-message;
+                    say 'File change detected, refreshing Humming-Bird...';
                     $!should-refresh = False;
                 }
             }

--- a/lib/Humming-Bird/Plugin/HotReload.rakumod
+++ b/lib/Humming-Bird/Plugin/HotReload.rakumod
@@ -45,7 +45,7 @@ class Humming-Bird::Backend::HotReload does Humming-Bird::Backend {
                 if ($!should-refresh) {
                     self!kill-server();
                     self!start-server();
-		    say $reload-message;
+		            say $reload-message;
                     say 'File change detected, refreshing Humming-Bird...';
                     $!should-refresh = False;
                 }


### PR DESCRIPTION
This PR aims to allow HotReload logging to not get immediately removed by a shell reset, prioritize /tmp for the HotReload PIDfile (while retaining the fallback for MacOS or NetBSD or whatever) and adds an integration test to check that the PIDfile can be written