### PR TITLE
Fix regex: quantifier on a `<(...)>` capture marker

### DIFF
--- a/lib/Humming-Bird/Glue.rakumod
+++ b/lib/Humming-Bird/Glue.rakumod
@@ -280,7 +280,7 @@ class Request is HTTPAction is export {
         # Absolute uris need their path encoded differently.
         without %headers<host> {
             my $abs-uri = $path;
-            $path = $abs-uri.match(/^'http' 's'? '://' <[A..Z a..z \w \. \- \_ 0..9]>+ <('/'.*)>? $/).Str;
+            $path = $abs-uri.match(/^'http' 's'? '://' <[A..Z a..z \w \. \- \_ 0..9]>+ <(['/'.*]?)> $/).Str;
             %headers<host> = $abs-uri.match(/^'http''s'?'://'(<-[/]>+)'/'?.* $/)[0].Str;
         }
 


### PR DESCRIPTION
`<('/'.*)>?` puts a `?` on the zero-width `)>` capture-end marker. A capture marker produces no match, so it cannot be quantified: the RakuAST compiler rejects it with "Can only quantify a construct that produces a match", and every file that loads Humming-Bird::Glue fails to compile. The legacy compiler accepted it, but its result was already wrong for a host-only absolute URI, where the whole match failed and it warned "Use of uninitialized value".

Move the `?` inside the capture: `<(['/'.*]?)>`. The extracted path is identical ("/path", or "" when there is none) on both compilers, and the spurious warning is gone.